### PR TITLE
fix: 빌드환경에서 스티커 저장 에러해결

### DIFF
--- a/src/components/diary/DiaryContainer.tsx
+++ b/src/components/diary/DiaryContainer.tsx
@@ -214,7 +214,6 @@ const DiaryContainer = () => {
           }));
 
           setStickers(stickersFromDB);
-          console.log('스티커디비', stickersFromDB);
         }
       } catch (error) {
         console.error('Error fetching stickers:', error);

--- a/src/components/diary/DiaryContainer.tsx
+++ b/src/components/diary/DiaryContainer.tsx
@@ -129,7 +129,7 @@ const DiaryContainer = () => {
     try {
       const stickersToSave = stickers.map((sticker) => ({
         ...sticker,
-        component: sticker.component.type.name
+        component: sticker.component.type.displayName as string
       }));
 
       const { data: existingStickerData, error: fetchError } = await supabase
@@ -214,6 +214,7 @@ const DiaryContainer = () => {
           }));
 
           setStickers(stickersFromDB);
+          console.log('스티커디비', stickersFromDB);
         }
       } catch (error) {
         console.error('Error fetching stickers:', error);

--- a/src/components/diary/assets/diary-stickers/AngerSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/AngerSticker.tsx
@@ -116,4 +116,6 @@ const AngerSticker = () => {
   );
 };
 
+AngerSticker.displayName = 'AngerSticker';
+
 export default AngerSticker;

--- a/src/components/diary/assets/diary-stickers/AnxietySticker.tsx
+++ b/src/components/diary/assets/diary-stickers/AnxietySticker.tsx
@@ -127,4 +127,6 @@ const AnxietySticker = () => {
   );
 };
 
+AnxietySticker.displayName = 'AnxietySticker';
+
 export default AnxietySticker;

--- a/src/components/diary/assets/diary-stickers/CalmSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/CalmSticker.tsx
@@ -82,4 +82,6 @@ const CalmSticker = () => {
   );
 };
 
+CalmSticker.displayName = 'CalmSticker';
+
 export default CalmSticker;

--- a/src/components/diary/assets/diary-stickers/ColorInsideTextSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/ColorInsideTextSticker.tsx
@@ -11,4 +11,6 @@ const ColorInsideTextSticker = () => {
   );
 };
 
+ColorInsideTextSticker.displayName = 'ColorInsideTextSticker';
+
 export default ColorInsideTextSticker;

--- a/src/components/diary/assets/diary-stickers/DoAnythingSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/DoAnythingSticker.tsx
@@ -11,4 +11,6 @@ const DoAnythingSticker = () => {
   );
 };
 
+DoAnythingSticker.displayName = 'DoAnythingSticker';
+
 export default DoAnythingSticker;

--- a/src/components/diary/assets/diary-stickers/FallFlowerSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/FallFlowerSticker.tsx
@@ -24,4 +24,6 @@ const FallFlowerSticker = () => {
   );
 };
 
+FallFlowerSticker.displayName = 'FallFlowerSticker';
+
 export default FallFlowerSticker;

--- a/src/components/diary/assets/diary-stickers/HappyDayTextSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/HappyDayTextSticker.tsx
@@ -11,4 +11,6 @@ const HappyDayTextSticker = () => {
   );
 };
 
+HappyDayTextSticker.displayName = 'HappyDayTextSticker';
+
 export default HappyDayTextSticker;

--- a/src/components/diary/assets/diary-stickers/HopeSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/HopeSticker.tsx
@@ -150,4 +150,6 @@ const HopeSticker = () => {
   );
 };
 
+HopeSticker.displayName = 'HopeSticker';
+
 export default HopeSticker;

--- a/src/components/diary/assets/diary-stickers/JoySticker.tsx
+++ b/src/components/diary/assets/diary-stickers/JoySticker.tsx
@@ -77,4 +77,6 @@ const JoySticker = () => {
   );
 };
 
+JoySticker.displayName = 'JoySticker';
+
 export default JoySticker;

--- a/src/components/diary/assets/diary-stickers/LethargySticker.tsx
+++ b/src/components/diary/assets/diary-stickers/LethargySticker.tsx
@@ -59,4 +59,6 @@ const LethargySticker = () => {
   );
 };
 
+LethargySticker.displayName = 'LethargySticker';
+
 export default LethargySticker;

--- a/src/components/diary/assets/diary-stickers/LogoSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/LogoSticker.tsx
@@ -39,4 +39,6 @@ const LogoSticker = () => {
   );
 };
 
+LogoSticker.displayName = 'LogoSticker';
+
 export default LogoSticker;

--- a/src/components/diary/assets/diary-stickers/NaSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/NaSticker.tsx
@@ -11,4 +11,6 @@ const NaSticker = () => {
   );
 };
 
+NaSticker.displayName = 'NaSticker';
+
 export default NaSticker;

--- a/src/components/diary/assets/diary-stickers/NoThoughtSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/NoThoughtSticker.tsx
@@ -11,4 +11,6 @@ const NoThoughtSticker = () => {
   );
 };
 
+NoThoughtSticker.displayName = 'NoThoughtSticker';
+
 export default NoThoughtSticker;

--- a/src/components/diary/assets/diary-stickers/PreciousMeSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/PreciousMeSticker.tsx
@@ -11,4 +11,6 @@ const PreciousMeSticker = () => {
   );
 };
 
+PreciousMeSticker.displayName = 'PreciousMeSticker';
+
 export default PreciousMeSticker;

--- a/src/components/diary/assets/diary-stickers/SadnessSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/SadnessSticker.tsx
@@ -73,4 +73,6 @@ const SadnessSticker = () => {
   );
 };
 
+SadnessSticker.displayName = 'SadnessSticker';
+
 export default SadnessSticker;

--- a/src/components/diary/assets/diary-stickers/SeedSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/SeedSticker.tsx
@@ -78,4 +78,6 @@ const SeedSticker = () => {
   );
 };
 
+SeedSticker.displayName = 'SeedSticker';
+
 export default SeedSticker;

--- a/src/components/diary/assets/diary-stickers/SpecialDaySticker.tsx
+++ b/src/components/diary/assets/diary-stickers/SpecialDaySticker.tsx
@@ -11,4 +11,6 @@ const SpecialDaySticker = () => {
   );
 };
 
+SpecialDaySticker.displayName = 'SpecialDaySticker';
+
 export default SpecialDaySticker;

--- a/src/components/diary/assets/diary-stickers/SpecialMeSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/SpecialMeSticker.tsx
@@ -11,4 +11,6 @@ const SpecialMeSticker = () => {
   );
 };
 
+SpecialMeSticker.displayName = 'SpecialMeSticker';
+
 export default SpecialMeSticker;

--- a/src/components/diary/assets/diary-stickers/SpringFlowerSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/SpringFlowerSticker.tsx
@@ -24,4 +24,6 @@ const SpringFlowerSticker = () => {
   );
 };
 
+SpringFlowerSticker.displayName = 'SpringFlowerSticker';
+
 export default SpringFlowerSticker;

--- a/src/components/diary/assets/diary-stickers/SummerFlowerSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/SummerFlowerSticker.tsx
@@ -12,4 +12,6 @@ const SummerFlowerSticker = () => {
   );
 };
 
+SummerFlowerSticker.displayName = 'SummerFlowerSticker';
+
 export default SummerFlowerSticker;

--- a/src/components/diary/assets/diary-stickers/TextGoodJobSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/TextGoodJobSticker.tsx
@@ -11,4 +11,6 @@ const TextGoodJobSticker = () => {
   );
 };
 
+TextGoodJobSticker.displayName = 'TextGoodJobSticker';
+
 export default TextGoodJobSticker;

--- a/src/components/diary/assets/diary-stickers/TextSeedSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/TextSeedSticker.tsx
@@ -11,4 +11,6 @@ const TextSeedSticker = () => {
   );
 };
 
+TextSeedSticker.displayName = 'TextSeedSticker';
+
 export default TextSeedSticker;

--- a/src/components/diary/assets/diary-stickers/WinterFlowerSticker.tsx
+++ b/src/components/diary/assets/diary-stickers/WinterFlowerSticker.tsx
@@ -16,4 +16,6 @@ const WinterFlowerSticker = () => {
   );
 };
 
+WinterFlowerSticker.displayName = 'WinterFlowerSticker';
+
 export default WinterFlowerSticker;


### PR DESCRIPTION
## Description

###  _스티커_

## 작업내용

- [ ]스티커 컴포넌트이름 빌드환경에서 축약되서 저장하는거 displayname 명시적으로 추가해서 해결


## ETC

### _[기타 사항]_

## 완료날짜

### 240820
